### PR TITLE
Replace Maptiler Basic by Coltrack Maptiler map

### DIFF
--- a/src/map/core/useMapStyles.js
+++ b/src/map/core/useMapStyles.js
@@ -113,7 +113,7 @@ export default () => {
     {
       id: 'mapTilerBasic',
       title: t('mapMapTilerBasic'),
-      style: `https://api.maptiler.com/maps/basic/style.json?key=${mapTilerKey}`,
+      style: `https://api.maptiler.com/maps/7e5db496-a1e8-4311-add0-90db83b0beb7/style.json?key=${mapTilerKey}`,
       available: !!mapTilerKey,
       attribute: 'mapTilerKey',
     },


### PR DESCRIPTION
**Overview**
This PR replaces the MapTiler basic map layer with the one selected by Coltrack.

**New Features**
- MapTiler Basic layer replaced

**Modified Core Files**
- **Files Modified**:
  -  `src/map/core/useMapStyles.js`
- **Reason for Modification**: One line of code was adjusted to replace the MapTiler Coltrack layer to the map by keeping intact the Traccar managment for Maptiler layers.

**Impact on Future Community Updates**
- **Files to Monitor**:
  - `src/main/MainPage.jsx`
  - `src/main/DeviceList.jsx`
  - `src/main/MainToolbar.jsx`
  - `src/map/core/useMapStyles.js`
- It is crucial to track changes to this file in community updates to ensure compatibility and address potential merge conflicts efficiently.

**Additional Notes**
- This PR builds upon the ideas proposed in PR #2  but with fewer modifications to the core source code, aligning with our strategy to minimize the impact on the Traccar core functionality.
- It is unnecessary to remove from the Code Google Layer support, add to the code the token or set the layer as default because all can be done using:
  - Settings -> Preferences: Active Maps
  - Settings -> Server: Default Map

**Conclusion**
This enhancement aligns with Coltrack’s goal of integrating customized elements into the Traccar interface while minimizing the impact on the core code.
