### PR TITLE
Adjust Mapbox layers by adding parameters to the tiles

### DIFF
--- a/src/map/core/useMapStyles.js
+++ b/src/map/core/useMapStyles.js
@@ -211,7 +211,7 @@ export default () => {
       id: 'mapboxStreets',
       title: t('mapMapboxStreets'),
       style: styleCustom({
-        tiles: [`https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}?access_token=${mapboxAccessToken}`],
+        tiles: [`https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/256/{z}/{x}/{y}@2x?access_token=${mapboxAccessToken}`],
         maxZoom: 22,
       }),
       available: !!mapboxAccessToken,
@@ -221,7 +221,7 @@ export default () => {
       id: 'mapboxStreetsDark',
       title: t('mapMapboxStreetsDark'),
       style: styleCustom({
-        tiles: [`https://api.mapbox.com/styles/v1/mapbox/dark-v11/tiles/{z}/{x}/{y}?access_token=${mapboxAccessToken}`],
+        tiles: [`https://api.mapbox.com/styles/v1/mapbox/dark-v11/tiles/256/{z}/{x}/{y}@2x?access_token=${mapboxAccessToken}`],
         maxZoom: 22,
       }),
       available: !!mapboxAccessToken,
@@ -231,7 +231,7 @@ export default () => {
       id: 'mapboxOutdoors',
       title: t('mapMapboxOutdoors'),
       style: styleCustom({
-        tiles: [`https://api.mapbox.com/styles/v1/mapbox/outdoors-v11/tiles/{z}/{x}/{y}?access_token=${mapboxAccessToken}`],
+        tiles: [`https://api.mapbox.com/styles/v1/mapbox/outdoors-v11/tiles/256/{z}/{x}/{y}@2x?access_token=${mapboxAccessToken}`],
         maxZoom: 22,
       }),
       available: !!mapboxAccessToken,
@@ -241,7 +241,7 @@ export default () => {
       id: 'mapboxSatelliteStreet',
       title: t('mapMapboxSatellite'),
       style: styleCustom({
-        tiles: [`https://api.mapbox.com/styles/v1/mapbox/satellite-streets-v11/tiles/{z}/{x}/{y}?access_token=${mapboxAccessToken}`],
+        tiles: [`https://api.mapbox.com/styles/v1/mapbox/satellite-streets-v11/tiles/256/{z}/{x}/{y}@2x?access_token=${mapboxAccessToken}`],
         maxZoom: 22,
       }),
       available: !!mapboxAccessToken,


### PR DESCRIPTION
**Overview**
This PR adjusts the tile size for Mapbox layers. A problem with the Traccar code makes the text on the layers look too small.


**New Features*
- Mapbox layers tile size are looking better.

**Modified Core Files**
- `src/map/core/useMapStyles.js`

**Impact on Future Community Updates**
- **Files to Monitor**:
  - `vite.config.js`
  - `src/App.jsx`
  - `src/index.jsx`
  - `src/map/core/useMapStyles.js`
  - `src/other/ReplayPage.jsx`
  - `src/common/components/PageLayout.jsx`

- It is crucial to track changes to this file in community updates to ensure compatibility and address potential merge conflicts efficiently.

Additionally, if the community updates the below files, we should evaluate if the updates are useful to be integrated into the customized files. See the `vite.config.js` alias.

**Additional Notes**
- This PR builds upon the request from Fernando Jimenez to support Font Awesome SVGs and is a partial solution to rotate markers depending on the heading.

**Conclusion**
This enhancement aligns with Coltrack’s goal of integrating customized elements into the Traccar interface while minimizing the impact on the core code.