### PR TITLE
Adjust core_coltrack/preloadImages.js preload to draw route color

### DIFF
--- a/src/map/core_coltrack/preloadImages.js
+++ b/src/map/core_coltrack/preloadImages.js
@@ -1,7 +1,6 @@
 import createPalette from '@mui/material/styles/createPalette';
 import { loadImage, prepareIcon } from './mapUtil';
 
-import arrowSvg from '../../resources/images/arrow.svg';
 import directionSvgError from '../../resources/images/coltrack/direction-error.svg';
 import directionSvgInfo from '../../resources/images/coltrack/direction-info.svg';
 import directionSvgNeutral from '../../resources/images/coltrack/direction-neutral.svg';
@@ -120,7 +119,6 @@ const mapPalette = createPalette({
 export default async () => {
   const background = await loadImage(backgroundSvg);
   mapImages.background = await prepareIcon(background);
-  mapImages.arrow = await prepareIcon(await loadImage(arrowSvg));
 
   mapImages['direction-neutral'] = await prepareIcon(await loadImage(directionSvgNeutral));
   mapImages['direction-info'] = await prepareIcon(await loadImage(directionSvgInfo));


### PR DESCRIPTION
**Overview**
This PR Adjusts the core_coltrack/preloadImages.js preload to draw routes with speed-based color, a feature introduced in recent updates to the main repository.

**New Features*
- Enable draw routes with speed-based color.

**Modified Core Files**
- None

**Impact on Future Community Updates**
- **Files to Monitor**:
  - `vite.config.js`
  - `src/App.jsx`
  - `src/index.jsx`
  - `src/map/core/useMapStyles.js`
  - `src/other/ReplayPage.jsx`
  - `src/common/components/PageLayout.jsx`

- It is crucial to track changes to this file in community updates to ensure compatibility and address potential merge conflicts efficiently.

Additionally, if the community updates the below files, we should evaluate if the updates are useful to be integrated into the customized files. See the `vite.config.js` alias.

**Additional Notes**
- This PR showcases the importance of keeping a forked repository that accepts the contributions from the community.

**Conclusion**
This enhancement aligns with Coltrack’s goal of integrating customized elements into the Traccar interface while minimizing the impact on the core code.