### PR TITLE
Bugfix/click on clusters

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-VITE_APP_VERSION=$npm_package_version

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@mapbox/mapbox-gl-draw": "^1.4.3",
         "@mapbox/mapbox-gl-geocoder": "^5.0.2",
         "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
-        "@maplibre/maplibre-gl-geocoder": "^1.5.0",
         "@mui/icons-material": "^5.15.19",
         "@mui/lab": "^5.0.0-alpha.170",
         "@mui/material": "^5.15.19",
@@ -2575,23 +2574,6 @@
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@maplibre/maplibre-gl-geocoder": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-geocoder/-/maplibre-gl-geocoder-1.5.0.tgz",
-      "integrity": "sha512-PsAbV7WFIOu5QYZne95FiXoV7AV1/6ULMjQxgInhZ5DdB0hDLjciQPegnyDgkzI8JfeqoUMZVS/MglZnSZYhyQ==",
-      "dependencies": {
-        "lodash.debounce": "^4.0.6",
-        "subtag": "^0.5.0",
-        "suggestions-list": "^0.0.2",
-        "xtend": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "maplibre-gl": ">=1.14.0"
       }
     },
     "node_modules/@mui/base": {
@@ -11350,15 +11332,6 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/suggestions/-/suggestions-1.7.1.tgz",
       "integrity": "sha512-gl5YPAhPYl07JZ5obiD9nTZsg4SyZswAQU/NNtnYiSnFkI3+ZHuXAiEsYm7AaZ71E0LXSFaGVaulGSWN3Gd71A==",
-      "dependencies": {
-        "fuzzy": "^0.1.1",
-        "xtend": "^4.0.0"
-      }
-    },
-    "node_modules/suggestions-list": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/suggestions-list/-/suggestions-list-0.0.2.tgz",
-      "integrity": "sha512-Yw0fdq14c6RQWQIfE1/8WEi9Dp8rjyCD6FhYA/Tit2/ADbE9Y4ADG4ezlvivsa8Civ5nz++pyVVBMjOMlgIUJw==",
       "dependencies": {
         "fuzzy": "^0.1.1",
         "xtend": "^4.0.0"

--- a/src/map_coltrack/MapPositions.js
+++ b/src/map_coltrack/MapPositions.js
@@ -94,11 +94,20 @@ const MapPositions = ({ positions, onClick, showStatus, selectedPosition, titleF
     const features = map.queryRenderedFeatures(event.point, {
       layers: [clusters],
     });
+
+    if (features.length === 0) return;
+
     const clusterId = features[0].properties.cluster_id;
-    const zoom = await map.getSource(id).getClusterExpansionZoom(clusterId);
-    map.easeTo({
-      center: features[0].geometry.coordinates,
-      zoom,
+    map.getSource(id).getClusterExpansionZoom(clusterId, (err, zoom) => {
+      if (err) {
+        console.error('Error getting cluster expansion zoom:', err);
+        return;
+      }
+
+      map.easeTo({
+        center: features[0].geometry.coordinates,
+        zoom: zoom,
+      });
     });
   }, [clusters]);
 


### PR DESCRIPTION
After implementing #19 there was a problem when clicking the map clusters. This PR fixes the issue.

The `.env` file is removed, and packages are upgraded.